### PR TITLE
Fix collapse_episode() edge cases and align backends

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # healthdb (development version)
 
+-   collapse_episode() now removes records with a missing (`NA`) start or end date (with a warning reporting the count) before deriving episodes, consistent with restrict_date(). Previously a single missing end date silently merged every later record of that client into one episode on the data.frame backend (an `NA` propagated through `cummax()`), and the data.frame and database backends disagreed on the result. Both backends now drop such records and agree.
+
+-   collapse_episode() on a data.frame now errors when a column would clash with the names it derives (`epi_id`, `epi_no`, `epi_seq`, `epi_start_dt`, `epi_stop_dt`, and internal helpers), matching the database method. Previously the data.frame method silently renamed the clashing column with an `_og` suffix.
+
+-   collapse_episode()'s `gap_overwrite` default is now `99999` on every backend (the data.frame method previously declared `Inf`, which was dead via S3 dispatch and would have produced `NA` on the database method). No change for typical calls through the generic.
+
+-   collapse_episode() on a zero-row data.frame no longer emits spurious "no non-missing arguments to min/max" warnings; it returns the empty result with the episode columns added.
+
 -   New vignette "The logic behind if_date() and restrict_date()" (`vignette("if_date_logic")`) explaining the within rolling window, the shrinking-window search for the apart condition, how the search loop is unrolled into SQL window functions with metaprogramming, and how these relate to known techniques.
 
 -   New vignette "Data wrangling helpers" (`vignette("wrangling")`) introducing report_n(), compute_duration(), lookup(), compute_comorbidity(), collapse_episode(), cut_period(), and if_date(), with guidance on keeping the work on the database for as long as possible.

--- a/R/collapse_episode.R
+++ b/R/collapse_episode.R
@@ -1,7 +1,7 @@
 #' Group records no more than n days apart as episodes
 #'
 #' @md
-#' @description This function is useful for collapsing, e.g., medication dispensation or hospitalization, records into episodes if the records' dates are no more than n days apart. The length of the gap can be relaxed by another grouping variable.
+#' @description This function is useful for collapsing, e.g., medication dispensation or hospitalization, records into episodes if the records' dates are no more than n days apart. The length of the gap can be relaxed by another grouping variable. Records with a missing (`NA`) start or end date are removed with a warning before episodes are derived, because the gap to such records is undefined.
 #' @param data A data.frame or remote table that contains the id and date variables.
 #' @param clnt_id Column name of subject/person ID.
 #' @param start_dt Column name of the starting date of records.
@@ -20,15 +20,34 @@
 #' @export
 #'
 #' @examples
-#' # make toy data
-#' df <- make_test_dat() %>%
-#'   dplyr::select(clnt_id, dates)
+#' # toy dispensing records: each row has a supply start and end date
+#' rx <- data.frame(
+#'   clnt_id = c(1, 1, 1, 2, 2),
+#'   start = as.Date(c(
+#'     "2020-01-01", "2020-03-01", "2020-06-01",
+#'     "2020-01-01", "2020-01-10"
+#'   )),
+#'   end = as.Date(c(
+#'     "2020-01-15", "2020-03-15", "2020-06-15",
+#'     "2020-01-20", "2020-01-25"
+#'   )),
+#'   rx_id = c("a", "a", "b", "c", "c")
+#' )
 #'
-#' head(df)
+#' # collapse records no more than 14 days apart into episodes
+#' collapse_episode(rx, clnt_id, start_dt = start, end_dt = end, gap = 14)
 #'
-#' # collapse records no more than 90 days apart
-#' # end_dt could be absent then it is assumed to be the same as start_dt
-#' collapse_episode(df, clnt_id, start_dt = dates, gap = 90)
+#' # end_dt may be omitted, then each record is assumed to last a single day
+#' collapse_episode(rx, clnt_id, start_dt = start, gap = 14)
+#'
+#' # overwrite keeps related records (e.g. refills of the same prescription)
+#' # in one episode regardless of the gap: consecutive records with the same
+#' # rx_id are collapsed using gap_overwrite, while a change in rx_id falls
+#' # back to the regular gap. Here client 1's two "a" records merge even though
+#' # they are more than 14 days apart.
+#' collapse_episode(rx, clnt_id,
+#'   start_dt = start, end_dt = end, gap = 14, overwrite = rx_id
+#' )
 collapse_episode <- function(data, clnt_id, start_dt, end_dt = NULL, gap, overwrite = NULL, gap_overwrite = 99999, .dt_trans = data.table::as.IDate, ...) {
   # input checks
 

--- a/R/collapse_episode_dataframe.R
+++ b/R/collapse_episode_dataframe.R
@@ -1,5 +1,5 @@
 #' @export
-collapse_episode.data.frame <- function(data, clnt_id, start_dt, end_dt = NULL, gap, overwrite = NULL, gap_overwrite = Inf, .dt_trans = data.table::as.IDate, ...) {
+collapse_episode.data.frame <- function(data, clnt_id, start_dt, end_dt = NULL, gap, overwrite = NULL, gap_overwrite = 99999, .dt_trans = data.table::as.IDate, ...) {
   # as_name(enquo(arg)) converts both quoted and unquoted column name to string
   clnt_id_nm <- rlang::as_name(rlang::enquo(clnt_id))
   start_dt_nm <- rlang::as_name(rlang::enquo(start_dt))
@@ -21,14 +21,25 @@ collapse_episode.data.frame <- function(data, clnt_id, start_dt, end_dt = NULL, 
 
   data <- data.table::as.data.table(data)
 
-  # treat potential name conflicts
+  # error on name conflicts (consistent with the database method)
   temp_cols <- c("last_end_dt", "scenario", "latest_end_dt")
   new_cols <- c("epi_id", "epi_no", "epi_seq", "epi_start_dt", "epi_stop_dt")
-  data.table::setnames(data, old = c(new_cols, temp_cols), new = paste(c(new_cols, temp_cols), "og", sep = "_", recycle0 = TRUE), skip_absent = TRUE)
+  if (any(colnames(data) %in% c(temp_cols, new_cols))) stop(paste("Existing variable names conflict those that will be used to derive episodes. Please rename or remove any of ", stringr::str_flatten_comma(c(temp_cols, new_cols))))
 
   # date transform
   if (!is.null(.dt_trans)) {
     data[, c(start_dt_nm, end_dt_nm) := lapply(.SD, function(x) .dt_trans(x, ...)), .SDcols = c(start_dt_nm, end_dt_nm)]
+  }
+
+  # drop records with missing dates before deriving gaps; an NA date makes the
+  # gap undefined and would otherwise propagate through cummax() and silently
+  # merge every later record into the same episode. Mirrors restrict_dates().
+  is_missing <- is.na(data[[start_dt_nm]])
+  if (has_end) is_missing <- is_missing | is.na(data[[end_dt_nm]])
+  n_missing <- sum(is_missing)
+  if (n_missing > 0) {
+    warning("Removed ", n_missing, " records with missing start_dt/end_dt")
+    data <- data[!is_missing]
   }
 
   # if end date was not supplied, treat it as the same as start
@@ -77,13 +88,19 @@ collapse_episode.data.frame <- function(data, clnt_id, start_dt, end_dt = NULL, 
   data[, epi_id := .GRP, by = c(clnt_id_nm, "epi_no")]
   # create seq# within an episode for each row
   data[, epi_seq := data.table::rowidv(epi_no), by = clnt_id_nm]
-  # summarize start and end date for each episode
-  data[, `:=`(
-    epi_start_dt = min(.SD[[start_dt_nm]], na.rm = TRUE),
-    epi_stop_dt = max(.SD[[end_dt_nm]], na.rm = TRUE)
-  ),
-  by = list(data[[clnt_id_nm]], epi_no), .SDcols = c(start_dt_nm, end_dt_nm)
-  ]
+  # summarize start and end date for each episode; guard the empty case so
+  # min()/max() do not warn ("no non-missing arguments") on zero-row input
+  if (nrow(data) > 0L) {
+    data[, `:=`(
+      epi_start_dt = min(.SD[[start_dt_nm]], na.rm = TRUE),
+      epi_stop_dt = max(.SD[[end_dt_nm]], na.rm = TRUE)
+    ),
+    by = list(data[[clnt_id_nm]], epi_no), .SDcols = c(start_dt_nm, end_dt_nm)
+    ]
+  } else {
+    # add the summary columns with the correct (empty) date types
+    data[, `:=`(epi_start_dt = data[[start_dt_nm]], epi_stop_dt = data[[end_dt_nm]])]
+  }
   # clean up aux variables
   data[, c(temp_cols) := NULL]
 

--- a/R/collapse_episode_sql.R
+++ b/R/collapse_episode_sql.R
@@ -34,6 +34,30 @@ collapse_episode.tbl_sql <- function(data, clnt_id, start_dt, end_dt = NULL, gap
   new_cols <- c("epi_id", "epi_no", "epi_seq", "epi_start_dt", "epi_stop_dt")
   if (any(colnames(data) %in% c(temp_cols, new_cols))) stop(paste("Existing variable names conflict those that will be used to derive episodes. Please rename or remove any of ", stringr::str_flatten_comma(c(temp_cols, new_cols))))
 
+  # drop records with missing dates before deriving gaps; an NA date makes the
+  # gap undefined and would otherwise be silently swept into a neighbouring
+  # episode (the backends even disagree on how NA flows through the window
+  # functions). Mirrors restrict_dates(); sum an explicit 1L/0L indicator for
+  # cross-dialect portability.
+  if (has_end) {
+    n_missing <- data %>%
+      dplyr::summarise(n_missing = sum(dplyr::if_else(is.na(.data[[start_dt_nm]]) | is.na(.data[[end_dt_nm]]), 1L, 0L), na.rm = TRUE))
+  } else {
+    n_missing <- data %>%
+      dplyr::summarise(n_missing = sum(dplyr::if_else(is.na(.data[[start_dt_nm]]), 1L, 0L), na.rm = TRUE))
+  }
+  n_missing <- n_missing %>%
+    dplyr::pull("n_missing") %>%
+    as.numeric()
+  if (isTRUE(n_missing > 0)) {
+    warning("Removed ", n_missing, " records with missing start_dt/end_dt")
+    if (has_end) {
+      data <- data %>% dplyr::filter(!is.na(.data[[start_dt_nm]]), !is.na(.data[[end_dt_nm]]))
+    } else {
+      data <- data %>% dplyr::filter(!is.na(.data[[start_dt_nm]]))
+    }
+  }
+
   # if end date was not supplied, treat it as the same as start
   if (!has_end) {
     end_dt_nm <- "temp_end"

--- a/man/collapse_episode.Rd
+++ b/man/collapse_episode.Rd
@@ -45,16 +45,35 @@ The original data.frame or remote table with new columns indicating episode grou
 }
 }
 \description{
-This function is useful for collapsing, e.g., medication dispensation or hospitalization, records into episodes if the records' dates are no more than n days apart. The length of the gap can be relaxed by another grouping variable.
+This function is useful for collapsing, e.g., medication dispensation or hospitalization, records into episodes if the records' dates are no more than n days apart. The length of the gap can be relaxed by another grouping variable. Records with a missing (\code{NA}) start or end date are removed with a warning before episodes are derived, because the gap to such records is undefined.
 }
 \examples{
-# make toy data
-df <- make_test_dat() \%>\%
-  dplyr::select(clnt_id, dates)
+# toy dispensing records: each row has a supply start and end date
+rx <- data.frame(
+  clnt_id = c(1, 1, 1, 2, 2),
+  start = as.Date(c(
+    "2020-01-01", "2020-03-01", "2020-06-01",
+    "2020-01-01", "2020-01-10"
+  )),
+  end = as.Date(c(
+    "2020-01-15", "2020-03-15", "2020-06-15",
+    "2020-01-20", "2020-01-25"
+  )),
+  rx_id = c("a", "a", "b", "c", "c")
+)
 
-head(df)
+# collapse records no more than 14 days apart into episodes
+collapse_episode(rx, clnt_id, start_dt = start, end_dt = end, gap = 14)
 
-# collapse records no more than 90 days apart
-# end_dt could be absent then it is assumed to be the same as start_dt
-collapse_episode(df, clnt_id, start_dt = dates, gap = 90)
+# end_dt may be omitted, then each record is assumed to last a single day
+collapse_episode(rx, clnt_id, start_dt = start, gap = 14)
+
+# overwrite keeps related records (e.g. refills of the same prescription)
+# in one episode regardless of the gap: consecutive records with the same
+# rx_id are collapsed using gap_overwrite, while a change in rx_id falls
+# back to the regular gap. Here client 1's two "a" records merge even though
+# they are more than 14 days apart.
+collapse_episode(rx, clnt_id,
+  start_dt = start, end_dt = end, gap = 14, overwrite = rx_id
+)
 }

--- a/tests/testthat/test-collapse_episode.R
+++ b/tests/testthat/test-collapse_episode.R
@@ -1,4 +1,6 @@
 test_that("basic use works", {
+  # seed the random fixture so failures are reproducible
+  set.seed(1)
   # generate test data
   data <- episode_df(10, 30)
   answer <- data[[1]]
@@ -11,6 +13,14 @@ test_that("basic use works", {
     out_df_start_only %>% dplyr::group_by(clnt) %>% dplyr::summarise(n_epi = max(epi_no)),
     answer %>% dplyr::group_by(clnt) %>% dplyr::summarise(n_epi = max(n_epi))
   )
+  # start-only path: epi_stop_dt should collapse to the episode's max start
+  epi_sum_start_only <- out_df_start_only %>%
+    dplyr::group_by(epi_id) %>%
+    dplyr::summarise(
+      max_start = max(segment_start),
+      epi_stop_dt = dplyr::first(epi_stop_dt)
+    )
+  expect_equal(epi_sum_start_only$epi_stop_dt, epi_sum_start_only$max_start)
   # test the summary of start/end is correct
   epi_sum_with_end <- out_df_with_end %>%
     dplyr::group_by(epi_id) %>%
@@ -26,6 +36,8 @@ test_that("basic use works", {
 })
 
 test_that("database input works", {
+  # seed the random fixture so failures are reproducible
+  set.seed(2)
   # generate test data
   data <- episode_df(10, 30, "db")
   answer <- data[[1]]
@@ -55,4 +67,141 @@ test_that("database input works", {
   # test name conflict warning
   db <- dplyr::rename(db, epi_id = segment_id)
   expect_error(collapse_episode(db, clnt_id = clnt, start_dt = segment_start, gap = 30), "conflict")
+})
+
+test_that("data.frame input errors on name conflicts", {
+  df <- data.frame(
+    clnt = 1L,
+    segment_start = as.Date(c("2020-01-01", "2020-02-01")),
+    epi_id = c("X", "Y")
+  )
+  expect_error(
+    collapse_episode(df, clnt_id = clnt, start_dt = segment_start, gap = 30, .dt_trans = NULL),
+    "conflict"
+  )
+})
+
+test_that("overwrite switches between gap and gap_overwrite", {
+  # A,A are ~50 days apart (> gap); B follows A
+  df <- data.frame(
+    clnt = 1L,
+    segment_start = as.Date(c("2020-01-01", "2020-03-01", "2020-06-01")),
+    segment_end = as.Date(c("2020-01-10", "2020-03-10", "2020-06-10")),
+    rx = c("A", "A", "B")
+  )
+
+  # same rx (A,A) collapsed under the relaxed gap_overwrite; the rx switch
+  # (A -> B) falls back to the regular gap and starts a new episode
+  out <- collapse_episode(df,
+    clnt_id = clnt, start_dt = segment_start, end_dt = segment_end,
+    gap = 10, overwrite = rx, gap_overwrite = 999, .dt_trans = NULL
+  )
+  expect_equal(out$epi_no, c(1, 1, 2))
+
+  # a tighter custom gap_overwrite the same-rx records now exceed forces a split
+  out2 <- collapse_episode(df,
+    clnt_id = clnt, start_dt = segment_start, end_dt = segment_end,
+    gap = 10, overwrite = rx, gap_overwrite = 20, .dt_trans = NULL
+  )
+  expect_equal(out2$epi_no, c(1, 2, 3))
+
+  # the database backend agrees on the relaxed case
+  out_db <- collapse_episode(memdb_tbl(df),
+    clnt_id = clnt, start_dt = segment_start, end_dt = segment_end,
+    gap = 10, overwrite = rx, gap_overwrite = 999
+  ) %>%
+    dplyr::collect() %>%
+    dplyr::arrange(segment_start)
+  expect_equal(out_db$epi_no, c(1, 1, 2))
+})
+
+test_that("records with missing dates are dropped with a warning", {
+  # the NA end date used to silently merge every later record into one episode
+  df <- data.frame(
+    clnt = 1L,
+    segment_start = as.Date(c("2020-01-01", "2020-01-05", "2020-01-20", "2020-01-25")),
+    segment_end = as.Date(c("2020-01-10", NA, "2020-01-22", "2020-01-30"))
+  )
+
+  expect_warning(
+    out <- collapse_episode(df,
+      clnt_id = clnt, start_dt = segment_start, end_dt = segment_end,
+      gap = 2, .dt_trans = NULL
+    ),
+    "missing"
+  )
+  expect_equal(nrow(out), 3)
+  expect_equal(out$epi_no, c(1, 2, 3))
+
+  expect_warning(
+    out_db <- collapse_episode(memdb_tbl(df),
+      clnt_id = clnt, start_dt = segment_start, end_dt = segment_end,
+      gap = 2
+    ) %>%
+      dplyr::collect(),
+    "missing"
+  )
+  expect_equal(nrow(out_db), 3)
+  expect_equal(sort(out_db$epi_no), c(1, 2, 3))
+
+  # a missing start date is dropped on the start-only path too
+  df2 <- data.frame(clnt = 1L, segment_start = as.Date(c("2020-01-01", NA, "2020-06-01")))
+  expect_warning(
+    out2 <- collapse_episode(df2, clnt_id = clnt, start_dt = segment_start, gap = 2, .dt_trans = NULL),
+    "missing"
+  )
+  expect_equal(nrow(out2), 2)
+  expect_equal(out2$epi_no, c(1, 2))
+})
+
+test_that("data.frame and database backends produce identical grouping", {
+  set.seed(123)
+  df <- data.frame(
+    clnt = rep(1:5, each = 5),
+    # sample without replacement -> starts are unique within each client,
+    # so the within-episode ordering is unambiguous across backends
+    segment_start = as.Date("2020-01-01") + sample(0:300, 25, replace = FALSE)
+  )
+  df <- df[order(df$clnt, df$segment_start), ]
+
+  out_df <- collapse_episode(df, clnt_id = clnt, start_dt = segment_start, gap = 14, .dt_trans = NULL) %>%
+    dplyr::arrange(clnt, segment_start)
+  out_db <- collapse_episode(memdb_tbl(df), clnt_id = clnt, start_dt = segment_start, gap = 14) %>%
+    dplyr::collect() %>%
+    dplyr::arrange(clnt, segment_start)
+
+  expect_equal(out_db$epi_no, out_df$epi_no)
+  expect_equal(out_db$epi_seq, out_df$epi_seq)
+  expect_equal(out_db$epi_id, out_df$epi_id)
+})
+
+test_that("start > end triggers a warning", {
+  df <- data.frame(
+    clnt = 1L,
+    segment_start = as.Date(c("2020-01-01", "2020-02-10")),
+    segment_end = as.Date(c("2020-01-31", "2020-02-05"))
+  )
+  expect_warning(
+    collapse_episode(df,
+      clnt_id = clnt, start_dt = segment_start, end_dt = segment_end,
+      gap = 5, .dt_trans = NULL
+    ),
+    "start > end"
+  )
+})
+
+test_that("single-row and empty input are handled", {
+  one <- data.frame(clnt = 1L, segment_start = as.Date("2020-01-01"))
+  out <- collapse_episode(one, clnt_id = clnt, start_dt = segment_start, gap = 30, .dt_trans = NULL)
+  expect_equal(out$epi_id, 1L)
+  expect_equal(out$epi_no, 1L)
+  expect_equal(out$epi_seq, 1L)
+
+  empty <- data.frame(clnt = integer(0), segment_start = as.Date(character(0)))
+  expect_no_warning(
+    out_empty <- collapse_episode(empty, clnt_id = clnt, start_dt = segment_start, gap = 30, .dt_trans = NULL)
+  )
+  expect_equal(nrow(out_empty), 0L)
+  expect_true(all(c("epi_id", "epi_no", "epi_seq", "epi_start_dt", "epi_stop_dt") %in% names(out_empty)))
+  expect_s3_class(out_empty$epi_start_dt, "Date")
 })

--- a/tests/testthat/test-define_case.R
+++ b/tests/testthat/test-define_case.R
@@ -90,6 +90,9 @@ test_that("keep first/last works on df", {
 })
 
 test_that("passing ... works", {
+  # seed the random fixture so the left/right comparison does not depend on
+  # global RNG state left by earlier tests (local_seed restores it on exit)
+  withr::local_seed(1)
   df <- make_test_dat()
   output_l <- define_case(df, starts_with("diagx"), "start", c("304"), clnt_id = clnt_id, mode = "filter", n_per_clnt = 2, date_var = dates, apart = 2, within = 365, uid = uid, force_collect = TRUE, flag_at = "left")
   output_r <- define_case(df, starts_with("diagx"), "start", c("304"), clnt_id = clnt_id, mode = "filter", n_per_clnt = 2, date_var = dates, apart = 2, within = 365, uid = uid, force_collect = TRUE, flag_at = "right")


### PR DESCRIPTION
## Summary

A review of `collapse_episode()` and its tests surfaced several correctness/consistency issues and gaps in coverage. This PR fixes them, aligns the data.frame and database backends, and refreshes the examples.

## Fixes

- **Missing dates are now dropped (with a warning) before deriving episodes.** Previously a single `NA` end date silently merged every later record of a client into one episode on the data.frame backend (the `NA` propagated through `cummax()`), and the two backends disagreed on the result. Both backends now drop records with a missing start/end and produce the same grouping. Mirrors `restrict_date()`'s existing behavior.
- **Name conflicts now error on the data.frame backend**, matching the database method. Previously the data.frame method silently renamed a clashing column (e.g. `epi_id`) with an `_og` suffix.
- **`gap_overwrite` default aligned to `99999` on every backend.** The data.frame method declared `Inf`, which was dead via S3 dispatch and would have produced `NA` on the database method (`as.integer(Inf)`).
- **Empty-input warnings fixed.** A zero-row data.frame no longer emits spurious `no non-missing arguments to min/max` warnings; it returns the empty result with the episode columns added.

## Tests

Expanded `test-collapse_episode.R`:
- Seeded the previously non-deterministic random fixtures.
- Real `overwrite` switching (the old test used `overwrite = clnt`, which only exercised the trivial always-collapse branch) and a custom `gap_overwrite`.
- Missing-date handling on both backends; data.frame name-conflict error.
- Cross-backend equality of `epi_id`/`epi_no`/`epi_seq` on identical input.
- `start > end` warning, single-row, and empty-input edge cases.

## Examples

Replaced the random `make_test_dat()` example with a small deterministic dispensing dataset that demonstrates `end_dt`, the start-only shortcut, and `overwrite`/`gap_overwrite` — so the printed output is meaningful and reproducible.

## Notes

The advisory `start > end` check remains data.frame-only; adding it to the database method would require an eager query, which cuts against keeping work lazy on the DB. The `NA` guard is eager too, but is justified because it fixes a real divergence in grouping output rather than just a warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)